### PR TITLE
MySqlConnector.csproj - disable code >= net5.0 code analysis

### DIFF
--- a/src/MySqlConnector/MySqlConnector.csproj
+++ b/src/MySqlConnector/MySqlConnector.csproj
@@ -13,6 +13,12 @@
     <Nullable>enable</Nullable>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Seems to cause conflicts sometimes with our other projects:
+    "CS8032 An instance of analyzer Microsoft.CodeAnalysis.X cannot be created from".
+    Could be the old target frameworks. This an external project anyway.
+    -->
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net471' ">


### PR DESCRIPTION
Occasionally getting this type of error:
```
Gravité	Code	Description	Projet	Fichier	Ligne	État de la suppression
Erreur	CS8032	Impossible de créer une instance de l'analyseur StyleCop.Analyzers.DocumentationRules.FileHeaderAnalyzers à partir de C:\Users\r3c\.nuget\packages\stylecop.analyzers.unstable\1.2.0.354\analyzers\dotnet\cs\StyleCop.Analyzers.dll : La méthode 'get_SupportedDiagnostics' du type 'StyleCop.Analyzers.DocumentationRules.FileHeaderAnalyzers' de l'assembly 'StyleCop.Analyzers, Version=1.2.0.354, Culture=neutral, PublicKeyToken=cfeb5dbada5e1c25' n'a pas d'implémentation..	MySqlConnector (net6.0)	C:\Users\r3c\Document\Work\Repository\monorepo\apps\submodules\MySqlConnector\src\MySqlConnector\CSC
```